### PR TITLE
Fix incorrect link to poedit

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A powerful color picker and formatter.
 
 <details>
   <summary>More screenshots</summary>
-  
+
 ![Light UI](data/resources/screenshots/main_window_ui_light.png)
 
 ![Customize the shown formats (Dark UI)](data/resources/screenshots/customized_formats_dark.png)
@@ -78,7 +78,7 @@ To contribute:
 
 Translations are a great way to contribute. This project uses the [GNU gettext](https://www.gnu.org/software/gettext/manual/html_node/index.html#SEC_Contents) for translations. If you want to learn more, visit the [translator section](https://www.gnu.org/software/gettext/manual/html_node/Translators.html#Translators).
 
-The easiest way to add a translation, is by importing the [`Eyedropper.pot`](po/Eyedropper.pot) file into a program like [Poedit](poedit.net) or [Gtranslator](https://gitlab.gnome.org/GNOME/gtranslator/).
+The easiest way to add a translation, is by importing the [`Eyedropper.pot`](po/Eyedropper.pot) file into a program like [Poedit](https://poedit.net) or [Gtranslator](https://gitlab.gnome.org/GNOME/gtranslator/).
 
 After finishing the translations, add the translated language code into the [LINGUAS](po/LINGUAS) file. Then follow the above steps to create a pull request. Please also state in the description if you are willing to maintain the translation.
 


### PR DESCRIPTION
Markdown interpreted it as relative link,
https://github.com/FineFindus/eyedropper/blob/master/poedit.net