### PR TITLE
window: Add tooltip to primary menu

### DIFF
--- a/data/resources/ui/window.ui
+++ b/data/resources/ui/window.ui
@@ -100,6 +100,7 @@
                         </child>
                         <child type="end">
                           <object class="GtkMenuButton" id="appmenu_button">
+                            <property name="tooltip-text" translatable="yes">Main Menu</property>
                             <property name="primary">true</property>
                             <property name="icon-name">open-menu-symbolic</property>
                             <property name="menu-model">primary_menu</property>


### PR DESCRIPTION
The HIG recommends the use of "Main Menu" for the primary menu.