### PR TITLE
data: Mark release descriptions as untranslatable

### DIFF
--- a/data/com.github.finefindus.eyedropper.metainfo.xml.in.in
+++ b/data/com.github.finefindus.eyedropper.metainfo.xml.in.in
@@ -51,7 +51,7 @@
     <p>A new release with exciting new features and many improvements.</p>\n<ul><li>Allow entering any format</li><li>Display color in overview search</li><li>Export palettes to LibreOffice</li><li>A visual differentiation between color and background</li><li>Improved color conversion</li><li>Visual refinements to match the state of the art of GNOME apps</li><li>Internal code improvements and bug fixes</li></ul>
     </release>
     <release version="0.6.0" date="2023-02-24">
-      <description>
+      <description translatable="no">
         <p>Added:</p>
         <ul>
           <li>Show a toast with an Undo option when clearing the history</li>
@@ -77,7 +77,7 @@
       </description>
     </release>
     <release version="0.5.1" date="2023-01-29">
-      <description>
+      <description translatable="no">
         <p>Added:</p>
         <ul>
           <li>Russian translation</li>
@@ -96,7 +96,7 @@
       </description>
     </release>
     <release version="0.5.0" date="2023-01-03">
-      <description>
+      <description translatable="no">
         <p>Added:</p>
         <ul>
           <li>Export the generated palettes from the palette dialog as a GIMP palette file</li>
@@ -114,7 +114,7 @@
       </description>
     </release>
     <release version="0.4.0" date="2022-10-20">
-      <description>
+      <description translatable="no">
         <p>Added:</p>
         <ul>
           <li>Options to show names of color (from w3c basic, extended and xkcd)</li>
@@ -129,12 +129,12 @@
       </description>
     </release>
     <release version="0.3.1" date="2022-09-23">
-      <description>
+      <description translatable="no">
         Fixed a few bugs and added Dutch translations.
       </description>
     </release>
     <release version="0.3.0" date="2022-09-21">
-      <description>
+      <description translatable="no">
         <p>Added:</p>
         <ul>
           <li>Palettes, consisting of darker shades and lighter tints, are now generated from the currently picked color as well as the previous 3</li>
@@ -146,7 +146,7 @@
       </description>
     </release>
     <release version="0.2.0" date="2022-09-08">
-      <description>
+      <description translatable="no">
         <p>Added:</p>
         <ul>
           <li>Issue and feature-request templates</li>
@@ -158,7 +158,7 @@
       </description>
     </release>
     <release version="0.1.0" date="2022-08-28">
-      <description>
+      <description translatable="no">
         <p>Added:</p>
         <ul>
           <li>Basic UI</li>


### PR DESCRIPTION
GNOME automatically excludes release descriptions on Damned Lies (GNOME Translation Platform). It's a good practice to follow the GNOME way.

This can streamline the translation process, allowing translators to focus their efforts on more critical and user-facing aspects of the application.