### PR TITLE
chore: update GNOME Circle URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Part of GNOME Circle](https://circle.gnome.org/assets/button/badge.svg)](https://apps.gnome.org/app/com.github.finefindus.eyedropper/)
+[![Part of GNOME Circle](https://circle.gnome.org/assets/button/badge.svg)](https://apps.gnome.org/Eyedropper/)
 ![maintenance-status](https://img.shields.io/badge/maintenance-actively--developed-brightgreen.svg)
 [![CI](https://github.com/FineFindus/eyedropper/actions/workflows/ci.yml/badge.svg)](https://github.com/FineFindus/eyedropper/actions/workflows/ci.yml)
 


### PR DESCRIPTION
Use the new simplified URL for apps.gnome.org.