### PR TITLE
Appstream related patches

### DIFF
--- a/data/com.github.finefindus.eyedropper.metainfo.xml.in.in
+++ b/data/com.github.finefindus.eyedropper.metainfo.xml.in.in
@@ -48,7 +48,9 @@
   <content_rating type="oars-1.1" />
   <releases>
     <release version="1.0.0" date="2023-09-27">
-    <p>A new release with exciting new features and many improvements.</p>\n<ul><li>Allow entering any format</li><li>Display color in overview search</li><li>Export palettes to LibreOffice</li><li>A visual differentiation between color and background</li><li>Improved color conversion</li><li>Visual refinements to match the state of the art of GNOME apps</li><li>Internal code improvements and bug fixes</li></ul>
+      <description translatable="no">
+        <p>A new release with exciting new features and many improvements.</p>\n<ul><li>Allow entering any format</li><li>Display color in overview search</li><li>Export palettes to LibreOffice</li><li>A visual differentiation between color and background</li><li>Improved color conversion</li><li>Visual refinements to match the state of the art of GNOME apps</li><li>Internal code improvements and bug fixes</li></ul>
+      </description>
     </release>
     <release version="0.6.0" date="2023-02-24">
       <description translatable="no">
@@ -179,7 +181,23 @@
     <kudo>ModernToolkit</kudo>
     <kudo>HiDpiIcon</kudo>
   </kudos>
-  <developer_name>FineFindus</developer_name>
+  <categories>
+    <category>GNOME</category>
+    <category>GTK</category>
+    <category>Development</category>
+    <category>Graphics</category>
+    <category>Utility</category>
+    <category>WebDevelopment</category>
+  </categories>
+  <keywords>
+    <keyword>Gnome</keyword>
+    <keyword>GTK</keyword>
+    <keyword>Color</keyword>
+    <keyword>Color Picker</keyword>
+    <keyword>Picker</keyword>
+    <keyword>Palette</keyword>
+  </keywords>
+  <developer_name translatable="no">FineFindus</developer_name>
   <update_contact>finefindusgh@gmail.com</update_contact>
   <translation type="gettext">@gettext-package@</translation>
   <launchable type="desktop-id">@app-id@.desktop</launchable>

--- a/data/meson.build
+++ b/data/meson.build
@@ -43,11 +43,11 @@ appdata_file = i18n.merge_file(
   install_dir: datadir / 'metainfo'
 )
 # Validate Appdata
-if appstream_util.found()
+if appstreamcli.found()
   test(
-    'validate-appdata', appstream_util,
+    'validate-appdata', appstreamcli,
     args: [
-      'validate', '--nonet', appdata_file.full_path()
+      'validate', '--no-net', appdata_file.full_path()
     ],
     depends: appdata_file,
   )

--- a/meson.build
+++ b/meson.build
@@ -18,7 +18,7 @@ dependency('gtk4', version: '>= 4.0.0')
 glib_compile_resources = find_program('glib-compile-resources', required: true)
 glib_compile_schemas = find_program('glib-compile-schemas', required: true)
 desktop_file_validate = find_program('desktop-file-validate', required: false)
-appstream_util = find_program('appstream-util', required: false)
+appstreamcli = find_program('appstreamcli', required: false)
 cargo = find_program('cargo', required: true)
 
 version = meson.project_version()


### PR DESCRIPTION
### appdata: Use appstreamcli for appdata validation

appstream-util is obsoleted by appstreamcli.

### appdata: Update appdata

- Add categories and keywords tags
- Mark the developer name as untranslatable
- Fix release invisible description error