### PR TITLE
Update .po files with current .pot file

### DIFF
--- a/po/ca.po
+++ b/po/ca.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Eyedropper\n"
 "Report-Msgid-Bugs-To: https://github.com/FineFindus/eyedropper\n"
 "POT-Creation-Date: 2023-11-14 19:29+0000\n"
-"PO-Revision-Date: 2023-12-16 16:35+0000\n"
+"PO-Revision-Date: 2023-12-19 14:11+0100\n"
 "Last-Translator: Milo Ivir <mail@milotype.de>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/eyedropper/"
 "eyedropper/ca/>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 5.3\n"
+"X-Generator: Poedit 3.0\n"
 
 #: data/com.github.finefindus.eyedropper.desktop.in.in:3
 #: data/com.github.finefindus.eyedropper.metainfo.xml.in.in:7
@@ -683,6 +683,14 @@ msgstr ""
 
 #: src/widgets/preferences/preferences_window.rs:411
 msgid "Hunter Lab"
+msgstr ""
+
+#: src/widgets/preferences/preferences_window.rs:413
+msgid "Oklab"
+msgstr ""
+
+#: src/widgets/preferences/preferences_window.rs:414
+msgid "Oklch"
 msgstr ""
 
 #: src/window.rs:272

--- a/po/de.po
+++ b/po/de.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Eyedropper\n"
 "Report-Msgid-Bugs-To: https://github.com/FineFindus/eyedropper\n"
 "POT-Creation-Date: 2023-11-14 19:29+0000\n"
-"PO-Revision-Date: 2023-12-03 16:20+0100\n"
+"PO-Revision-Date: 2023-12-19 14:13+0100\n"
 "Last-Translator: Milo Ivir <mail@milotype.de>\n"
 "Language-Team: \n"
 "Language: de\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 5.3\n"
+"X-Generator: Poedit 3.0\n"
 
 #: data/com.github.finefindus.eyedropper.desktop.in.in:3
 #: data/com.github.finefindus.eyedropper.metainfo.xml.in.in:7
@@ -412,6 +412,14 @@ msgstr "LMS Format"
 #: data/resources/ui/preferences/preferences.blp:199
 msgid "Hunter Lab Format"
 msgstr "Hunter Lab Format"
+
+#: data/resources/ui/preferences/preferences.blp:205
+msgid "Oklab Format"
+msgstr ""
+
+#: data/resources/ui/preferences/preferences.blp:211
+msgid "Oklch Format"
+msgstr ""
 
 #: data/resources/ui/shortcuts.blp:11
 msgctxt "shortcut window"

--- a/po/fr.po
+++ b/po/fr.po
@@ -9,7 +9,7 @@ msgstr ""
 "Project-Id-Version: Eyedropper master\n"
 "Report-Msgid-Bugs-To: https://github.com/FineFindus/eyedropper\n"
 "POT-Creation-Date: 2023-11-14 19:29+0000\n"
-"PO-Revision-Date: 2023-12-03 16:20+0100\n"
+"PO-Revision-Date: 2023-12-19 14:14+0100\n"
 "Last-Translator: Milo Ivir <mail@milotype.de>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/eyedropper/"
 "eyedropper/fr/>\n"
@@ -416,6 +416,14 @@ msgstr "Format LMS"
 #: data/resources/ui/preferences/preferences.blp:199
 msgid "Hunter Lab Format"
 msgstr "Format Hunter Lab"
+
+#: data/resources/ui/preferences/preferences.blp:205
+msgid "Oklab Format"
+msgstr ""
+
+#: data/resources/ui/preferences/preferences.blp:211
+msgid "Oklch Format"
+msgstr ""
 
 #: data/resources/ui/shortcuts.blp:11
 msgctxt "shortcut window"

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,8 +7,8 @@ msgstr ""
 "Project-Id-Version: com.github.finefindus.eyedropper\n"
 "Report-Msgid-Bugs-To: https://github.com/FineFindus/eyedropper\n"
 "POT-Creation-Date: 2023-11-14 19:29+0000\n"
-"PO-Revision-Date: 2023-12-18 12:06+0000\n"
-"Last-Translator: Sabri Ünal <libreajans@gmail.com>\n"
+"PO-Revision-Date: 2023-12-19 14:15+0100\n"
+"Last-Translator: Milo Ivir <mail@milotype.de>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/eyedropper/"
 "eyedropper/tr/>\n"
 "Language: tr\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: Weblate 5.3\n"
+"X-Generator: Poedit 3.0\n"
 
 #: data/com.github.finefindus.eyedropper.desktop.in.in:3
 #: data/com.github.finefindus.eyedropper.metainfo.xml.in.in:7
@@ -698,7 +698,15 @@ msgstr "LMS"
 msgid "Hunter Lab"
 msgstr "Hunter Lab"
 
-#: src/window.rs:222
+#: src/widgets/preferences/preferences_window.rs:413
+msgid "Oklab"
+msgstr ""
+
+#: src/widgets/preferences/preferences_window.rs:414
+msgid "Oklch"
+msgstr ""
+
+#: src/window.rs:272
 msgid "Cleared history"
 msgstr "Geçmiş temizlendi"
 

--- a/po/uk.po
+++ b/po/uk.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Eyedropper\n"
 "Report-Msgid-Bugs-To: https://github.com/FineFindus/eyedropper\n"
 "POT-Creation-Date: 2023-11-14 19:29+0000\n"
-"PO-Revision-Date: 2023-12-03 14:49+0100\n"
+"PO-Revision-Date: 2023-12-19 14:15+0100\n"
 "Last-Translator: Milo Ivir <mail@milotype.de>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/eyedropper/"
 "eyedropper/uk/>\n"
@@ -701,7 +701,15 @@ msgstr "LMS"
 msgid "Hunter Lab"
 msgstr "Hunter Lab"
 
-#: src/window.rs:222
+#: src/widgets/preferences/preferences_window.rs:413
+msgid "Oklab"
+msgstr ""
+
+#: src/widgets/preferences/preferences_window.rs:414
+msgid "Oklch"
+msgstr ""
+
+#: src/window.rs:272
 msgid "Cleared history"
 msgstr "Історія видалена"
 

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Eyedropper\n"
 "Report-Msgid-Bugs-To: https://github.com/FineFindus/eyedropper\n"
 "POT-Creation-Date: 2023-11-14 19:29+0000\n"
-"PO-Revision-Date: 2023-12-03 16:19+0100\n"
+"PO-Revision-Date: 2023-12-19 14:16+0100\n"
 "Last-Translator: Milo Ivir <mail@milotype.de>\n"
 "Language-Team: Chinese - China <i18n-zh@googlegroups.com>\n"
 "Language: zh_CN\n"
@@ -687,7 +687,15 @@ msgstr "LMS"
 msgid "Hunter Lab"
 msgstr "Hunter Lab"
 
-#: src/window.rs:224
+#: src/widgets/preferences/preferences_window.rs:413
+msgid "Oklab"
+msgstr ""
+
+#: src/widgets/preferences/preferences_window.rs:414
+msgid "Oklch"
+msgstr ""
+
+#: src/window.rs:272
 msgid "Cleared history"
 msgstr "已清除历史"
 


### PR DESCRIPTION
For some reason the following six .po files didn't update correctly with the issue #104 (neither at Hosted Weblate nor at GitHub). They all still have only 151 strings instead of 153 strings.
ca.po
de.po
fr.po
tr.po
uk.po
zh_CN.po

The current "Eyedropper.pot" file with the Creation-Date in the header ("POT-Creation-Date: 2023-11-14 19:29+0000\n") has 153 strings.

In this commit I've just updated the above six files with the current "Eyedropper.pot" file again, without any other changes concearning the translation of strings.

Once the files are merged on GitHub, please also update those translation files on https://hosted.weblate.org/projects/eyedropper/eyedropper/ and I could add those "obvious translations" at Hosted Weblate.