### PR TITLE
feat(appdata): Improve appdata for AppStream 1.0

### DIFF
--- a/data/com.github.finefindus.eyedropper.metainfo.xml.in.in
+++ b/data/com.github.finefindus.eyedropper.metainfo.xml.in.in
@@ -6,7 +6,11 @@
   <project_license>GPL-3.0</project_license>
   <name>Eyedropper</name>
   <summary>Pick and format colors</summary>
+  <!-- developer_name tag deprecated with Appstream 1.0 -->
   <developer_name translatable="no">FineFindus</developer_name>
+  <developer id="github.com">
+      <name translatable="no">FineFindus</name>
+  </developer>
   <update_contact>finefindus@proton.me</update_contact>
   <project_group>GNOME</project_group>
   <description>

--- a/data/com.github.finefindus.eyedropper.metainfo.xml.in.in
+++ b/data/com.github.finefindus.eyedropper.metainfo.xml.in.in
@@ -184,22 +184,6 @@
     <kudo>ModernToolkit</kudo>
     <kudo>HiDpiIcon</kudo>
   </kudos>
-  <categories>
-    <category>GNOME</category>
-    <category>GTK</category>
-    <category>Development</category>
-    <category>Graphics</category>
-    <category>Utility</category>
-    <category>WebDevelopment</category>
-  </categories>
-  <keywords>
-    <keyword>Gnome</keyword>
-    <keyword>GTK</keyword>
-    <keyword>Color</keyword>
-    <keyword>Color Picker</keyword>
-    <keyword>Picker</keyword>
-    <keyword>Palette</keyword>
-  </keywords>
   <translation type="gettext">@gettext-package@</translation>
   <launchable type="desktop-id">@app-id@.desktop</launchable>
 

--- a/data/meson.build
+++ b/data/meson.build
@@ -47,7 +47,7 @@ if appstreamcli.found()
   test(
     'validate-appdata', appstreamcli,
     args: [
-      'validate', '--no-net', appdata_file.full_path()
+      'validate', '--no-net', '--explain', appdata_file.full_path()
     ],
     depends: appdata_file,
   )


### PR DESCRIPTION
### feat(appdata): Improve appdata for AppStream 1.0

- Add the `<developer><name>` tag
- Mark the `<developer_name>` tag as deprecated
- Improve appstreamcli arguments

### chore: remove categories

"Icons and categories

If there’s a type="desktop-id" launchable, they get pulled from it.
Most of the icon not found errors with the flathub builder can be
traced down to the launchable value not matching the desktop file name.

Don’t set them in the AppData unless you want to override them
(even though then it might be a better idea to patch the desktop file
itself)."