### PR TITLE
Update developer ID

### DIFF
--- a/data/com.github.finefindus.eyedropper.metainfo.xml.in.in
+++ b/data/com.github.finefindus.eyedropper.metainfo.xml.in.in
@@ -8,7 +8,7 @@
   <summary>Pick and format colors</summary>
   <!-- developer_name tag deprecated with Appstream 1.0 -->
   <developer_name translatable="no">FineFindus</developer_name>
-  <developer id="github.com">
+  <developer id="io.github.finefindus">
       <name translatable="no">FineFindus</name>
   </developer>
   <update_contact>finefindus@proton.me</update_contact>


### PR DESCRIPTION
Appstream decided to use reverse DNS for developer IDds.

> The element should have a id property, containing a unique ID to identify the component developer / development team. It is recommended to use a reverse-DNS name, like org.gnome or io.github.ximion, or a Fediverse handle (like @user@example.org) as ID to achieve a higher chance of uniqueness.

More information: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-developer