### PR TITLE
feat(window): Add random color button to placeholder page

### DIFF
--- a/data/com.github.finefindus.eyedropper.gschema.xml.in
+++ b/data/com.github.finefindus.eyedropper.gschema.xml.in
@@ -2,11 +2,11 @@
 <schemalist>
   <schema path="/com/github/finefindus/eyedropper/" id="@app-id@" gettext-domain="@gettext-package@">
     <key name="window-width" type="i">
-      <default>300</default>
+      <default>360</default>
       <summary>Window width</summary>
     </key>
     <key name="window-height" type="i">
-      <default>445</default>
+      <default>500</default>
       <summary>Window height</summary>
     </key>
     <key name="is-maximized" type="b">

--- a/data/resources/ui/window.blp
+++ b/data/resources/ui/window.blp
@@ -52,16 +52,32 @@ template $AppWindow: Adw.ApplicationWindow {
               title: _("No Color");
               description: _("Select a color from the screen to get started");
 
-              child: Button {
-                label: _("_Pick a Color");
-                use-underline: true;
-                halign: center;
-                action-name: "app.pick_color";
+              child: Box {
+                orientation: vertical;
+                spacing: 12;
 
-                styles [
-                  "pill",
-                  "suggested-action",
-                ]
+                Button {
+                  label: _("_Pick a Color");
+                  use-underline: true;
+                  halign: center;
+                  action-name: "app.pick_color";
+
+                  styles [
+                    "pill",
+                    "suggested-action",
+                  ]
+                }
+
+                Button {
+                  label: _("_Random Color");
+                  use-underline: true;
+                  halign: center;
+                  action-name: "app.random_color";
+
+                  styles [
+                    "pill",
+                  ]
+                }
               };
             };
           };


### PR DESCRIPTION
Starting with a random color is already possible with the `Ctrl+R` shortcut. This change makes it more visible and accessible.

Also enlarge the window a bit to avoid scrolling with the new button.