### PR TITLE
search provider: Don't try to process if ID is invalid

### DIFF
--- a/src/application.rs
+++ b/src/application.rs
@@ -320,7 +320,11 @@ impl SearchProviderImpl for App {
     fn activate_result(&self, identifier: ResultID, _terms: &[String], _timestamp: u32) {
         self.activate();
         let window = self.main_window();
-        window.set_color(gdk::RGBA::parse(identifier).unwrap().into());
+
+        if let Ok(rgba) = gdk::RGBA::parse(identifier) {
+            window.set_color(rgba.into());
+        }
+
         window.present();
     }
 
@@ -335,15 +339,14 @@ impl SearchProviderImpl for App {
     fn result_metas(&self, identifiers: &[ResultID]) -> Vec<ResultMeta> {
         identifiers
             .iter()
-            .map(|identifier| {
-                ResultMeta::builder(identifier.to_owned(), identifier)
-                    .icon_data(IconData::from(
-                        &App::icon(
-                            gdk::RGBA::parse(identifier).expect("Failed to parse identifier color"),
-                        )
-                        .expect("Failed to render search icon"),
-                    ))
-                    .build()
+            .filter_map(|identifier| {
+                Some(
+                    ResultMeta::builder(identifier.to_owned(), identifier)
+                        .icon_data(IconData::from(
+                            &App::icon(gdk::RGBA::parse(identifier).ok()?).ok()?,
+                        ))
+                        .build(),
+                )
             })
             .collect::<Vec<_>>()
     }


### PR DESCRIPTION
It causes a panic if invalid ID is sent via D-Bus.

```
$ gdbus call -e -d com.github.finefindus.eyedropper.SearchProvider -o /com/github/finefindus/eyedropper/SearchProvider -m org.gnome.Shell.SearchProvider2.GetResultMetas '["invalid"]'
```
```
$ gdbus call -e -d com.github.finefindus.eyedropper.SearchProvider -o /com/github/finefindus/eyedropper/SearchProvider -m org.gnome.Shell.SearchProvider2.ActivateResult "invalid" "[]" 0
```
Which causes the following panic:
```
thread 'main' panicked at src/application.rs:266:58:
Failed to parse identifier color: BoolError { message: "Can't parse RGBA", filename: "/usr/src/debug/eyedropper/build/cargo-home/registry/src/index.crates.io-1949cf8c6b5b557f/gdk4-0.9.6/src/rgba.rs", function: "gdk4::rgba::<impl gdk4::auto::rgba::RGBA>::parse::{{closure}}", line: 207 }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

thread 'zbus::Connection executor' panicked at /usr/src/debug/eyedropper/build/cargo-home/registry/src/index.crates.io-1949cf8c6b5b557f/search-provider-0.11.0/src/search_provider.rs:157:39:
called `Result::unwrap()` on an `Err` value: Canceled
```
```
thread 'main' panicked at src/application.rs:247:55:
called `Result::unwrap()` on an `Err` value: BoolError { message: "Can't parse RGBA", filename: "/usr/src/debug/eyedropper/build/cargo-home/registry/src/index.crates.io-1949cf8c6b5b557f/gdk4-0.9.6/src/rgba.rs", function: "gdk4::rgba::<impl gdk4::auto::rgba::RGBA>::parse::{{closure}}", line: 207 }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
This change fixes that.