### PR TITLE
Add D-Bus service file

### DIFF
--- a/data/com.github.finefindus.eyedropper.desktop.in.in
+++ b/data/com.github.finefindus.eyedropper.desktop.in.in
@@ -11,3 +11,4 @@ Keywords=Gnome;GTK;Color;Colorpicker;Picker;Palette;
 # Translators: Do NOT translate or transliterate this text (this is an icon file name)!
 Icon=@icon@
 StartupNotify=true
+DBusActivatable=true

--- a/data/com.github.finefindus.eyedropper.service.in
+++ b/data/com.github.finefindus.eyedropper.service.in
@@ -1,0 +1,3 @@
+[D-BUS Service]
+Name=@appid@
+Exec=@bindir@/@name@ --gapplication-service

--- a/data/meson.build
+++ b/data/meson.build
@@ -75,11 +75,17 @@ if glib_compile_schemas.found()
   )
 endif
 
-# Search Provider
+# D-Bus service file and Search Provider
 service_conf = configuration_data()
 service_conf.set('appid', application_id)
 service_conf.set('name', meson.project_name())
 service_conf.set('bindir', bindir)
+configure_file(
+  input: '@0@.service.in'.format(base_id),
+  output: '@0@.service'.format(application_id),
+  configuration: service_conf,
+  install_dir: datadir / 'dbus-1' / 'services'
+)
 configure_file(
   input: '@0@.SearchProvider.service.in'.format(base_id),
   output: '@0@.SearchProvider.service'.format(application_id),


### PR DESCRIPTION
And mark the application as D-Bus activatable. This allows application launchers to activate it via D-Bus.

Reference:
https://specifications.freedesktop.org/desktop-entry-spec/1.3/dbus.html