### PR TITLE
Switch to placeholder page after error

### DIFF
--- a/data/resources/ui/window.blp
+++ b/data/resources/ui/window.blp
@@ -119,7 +119,7 @@ template $AppWindow: Adw.ApplicationWindow {
                     label: _("_Continue Regardless");
                     use-underline: true;
                     halign: center;
-                    action-name: "app.random-color";
+                    action-name: "app.placeholder";
 
                     styles [
                       "pill",

--- a/src/application.rs
+++ b/src/application.rs
@@ -187,12 +187,20 @@ impl App {
             })
             .build();
 
+        // Switch to placeholder page
+        let action_placeholder = gio::ActionEntry::builder("placeholder")
+            .activate(|app: &Self, _, _| {
+                app.main_window().show_placeholder_page();
+            })
+            .build();
+
         self.add_action_entries([
             action_clear_history,
             action_random_color,
             action_preferences,
             action_quit,
             action_about,
+            action_placeholder,
         ]);
     }
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -540,4 +540,9 @@ impl AppWindow {
         self.set_color(color);
         self.imp().edit_sheet.set_open(false);
     }
+
+    /// Shows the placeholder page.
+    pub fn show_placeholder_page(&self) {
+        self.imp().stack.set_visible_child_name("placeholder");
+    }
 }


### PR DESCRIPTION
When the user clicks on the "Continue Regardless" button, show the placeholder page instead of showing a random color.