### PR TITLE
feat: add picker action to placeholder page

### DIFF
--- a/data/resources/ui/placeholder-page.blp
+++ b/data/resources/ui/placeholder-page.blp
@@ -13,6 +13,18 @@ template $PlaceholderPage: Adw.Bin {
       spacing: 25;
       orientation: vertical;
 
+      Button {
+        label: _("_Pick a Color");
+        use-underline: true;
+        halign: center;
+        action-name: "win.pick-color";
+
+        styles [
+          "pill",
+          "suggested-action",
+        ]
+      }
+
       Entry initial_color_entry {
         placeholder-text: "#2190A4";
         activate => $on_color_entry_active() swapped;
@@ -26,7 +38,6 @@ template $PlaceholderPage: Adw.Bin {
 
         styles [
           "pill",
-          "suggested-action",
         ]
       }
     };


### PR DESCRIPTION
## Summary

- restore a prominent **Pick a Color** action on the empty-state page
- reuse the existing `win.pick-color` action used by the header button
- keep manual color entry available while making its **View** button secondary

## Validation

- `blueprint-compiler compile --output /tmp/placeholder.ui data/resources/ui/placeholder-page.blp`
- `xmllint --noout /tmp/placeholder.ui`
- `ninja -C <build-dir> data/resources/resources.gresource`
- `cargo fmt --all -- --check`
- `git diff --check`

A full Meson build generated the Blueprint/resources successfully, then stopped in the Rust dependency build on macOS because the Linux-only `gtk4-wayland` and `gtk4-x11` pkg-config files are unavailable locally. The repository CI remains authoritative for the Linux build.

Closes #234